### PR TITLE
Fix TrackedLink onClick

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## TypeScript Check
+
+Run `npm install` to install dependencies before running `npx tsc --noEmit`. If you see errors about missing image modules, ensure `next-env.d.ts` exists by running `npm run dev` once or create the file with references to `next` and `next/image-types`.
+

--- a/components/TrackedLink.tsx
+++ b/components/TrackedLink.tsx
@@ -1,14 +1,22 @@
 import { createTracking } from '@/lib/actions';
 import Link from 'next/link';
+import type React from 'react';
 
 type TrackedLinkProps = React.ComponentPropsWithoutRef<typeof Link> & {
   tag: string;
 };
 
-function TrackedLink(props: TrackedLinkProps) {
+function TrackedLink({ tag, onClick, ...rest }: TrackedLinkProps) {
+  const handleClick: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
+    void createTracking(tag);
+    if (typeof onClick === 'function') {
+      onClick(e);
+    }
+  };
+
   return (
-    <Link {...props} onClick={() => createTracking(props.tag)}>
-      {props.children}
+    <Link {...rest} onClick={handleClick}>
+      {rest.children}
     </Link>
   );
 }


### PR DESCRIPTION
## Summary
- preserve onClick handler when tracking link clicks
- document how to run `npx tsc`

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6849e942b6008320982e153ad5bdfd61